### PR TITLE
Change structs back to classes

### DIFF
--- a/SharpBox2D/Common/Mat22.cs
+++ b/SharpBox2D/Common/Mat22.cs
@@ -31,7 +31,7 @@ namespace SharpBox2D.Common
 /**
  * A 2-by-2 matrix. Stored in column-major order.
  */
-    public struct Mat22 : IEquatable<Mat22>
+    public class Mat22 : IEquatable<Mat22>
     {
         public Vec2 ex, ey;
 
@@ -51,6 +51,12 @@ namespace SharpBox2D.Common
    * @param c1 Column 1 of matrix
    * @param c2 Column 2 of matrix
    */
+        
+        public Mat22()
+        {
+            ex = new Vec2(1, 0);
+            ey = new Vec2(0, 1);
+        }
 
         public Mat22(Vec2 c1, Vec2 c2)
         {
@@ -308,10 +314,22 @@ namespace SharpBox2D.Common
 
         public void mulLocal(Mat22 R)
         {
-            mulToOut(R, ref this);
+            mulToOut(R, this);
         }
 
         public void mulToOut(Mat22 R, ref Mat22 m)
+        {
+            float tempy1 = this.ex.y*R.ex.x + this.ey.y*R.ex.y;
+            float tempx1 = this.ex.x*R.ex.x + this.ey.x*R.ex.y;
+            m.ex.x = tempx1;
+            m.ex.y = tempy1;
+            float tempy2 = this.ex.y*R.ey.x + this.ey.y*R.ey.y;
+            float tempx2 = this.ex.x*R.ey.x + this.ey.x*R.ey.y;
+            m.ey.x = tempx2;
+            m.ey.y = tempy2;
+        }
+
+        public void mulToOut(Mat22 R, Mat22 m)
         {
             float tempy1 = this.ex.y*R.ex.x + this.ey.y*R.ex.y;
             float tempx1 = this.ex.x*R.ex.x + this.ey.x*R.ex.y;
@@ -360,7 +378,7 @@ namespace SharpBox2D.Common
 
         public void mulTransLocal(Mat22 B)
         {
-            mulTransToOut(B, ref this);
+            mulTransToOut(B, this);
         }
 
         public void mulTransToOut(Mat22 B, ref Mat22 m)
@@ -379,6 +397,22 @@ namespace SharpBox2D.Common
             m.ey.y = y2;
         }
 
+        public void mulTransToOut(Mat22 B, Mat22 m)
+        {
+            /*
+     * ref.ex.x = Vec2.dot(this.ex, B.ex); ref.ex.y = Vec2.dot(this.ey, B.ex); ref.ey.x =
+     * Vec2.dot(this.ex, B.ey); ref.ey.y = Vec2.dot(this.ey, B.ey);
+     */
+            float x1 = this.ex.x*B.ex.x + this.ex.y*B.ex.y;
+            float y1 = this.ey.x*B.ex.x + this.ey.y*B.ex.y;
+            float x2 = this.ex.x*B.ey.x + this.ex.y*B.ey.y;
+            float y2 = this.ey.x*B.ey.x + this.ey.y*B.ey.y;
+            m.ex.x = x1;
+            m.ey.x = x2;
+            m.ex.y = y1;
+            m.ey.y = y2;
+        }
+         
         public void mulTransToOutUnsafe(Mat22 B, ref Mat22 m)
         {
             Debug.Assert(B != m);

--- a/SharpBox2D/Common/Mat33.cs
+++ b/SharpBox2D/Common/Mat33.cs
@@ -33,7 +33,7 @@ namespace SharpBox2D.Common
  * @author Daniel Murphy
  */
 
-    public struct Mat33
+    public class Mat33
     {
         public static readonly Mat33 IDENTITY = new Mat33(new Vec3(1, 0, 0), new Vec3(0, 1, 0), new Vec3(0,
             0, 1));
@@ -53,6 +53,13 @@ namespace SharpBox2D.Common
             ex = argCol1.clone();
             ey = argCol2.clone();
             ez = argCol3.clone();
+        }
+        
+        public Mat33()
+        {
+            ex = IDENTITY.ex.clone();
+            ey = IDENTITY.ex.clone();
+            ez = IDENTITY.ex.clone();
         }
 
         public void setZero()

--- a/SharpBox2D/Common/Rot.cs
+++ b/SharpBox2D/Common/Rot.cs
@@ -33,7 +33,7 @@ using System.Diagnostics;
 
 namespace SharpBox2D.Common
 {
-    public struct Rot : IEquatable<Rot>
+    public class Rot : IEquatable<Rot>
     {
         public float s;
         public float c; // sin and cos
@@ -41,6 +41,11 @@ namespace SharpBox2D.Common
         public Rot(float angle) : this()
         {
             set(angle);
+        }
+        
+        public Rot()
+        {
+            set(0);
         }
 
         public float getSin()

--- a/SharpBox2D/Common/Transform.cs
+++ b/SharpBox2D/Common/Transform.cs
@@ -35,7 +35,7 @@ namespace SharpBox2D.Common
  * orientation of rigid frames.
  */
 
-    public struct Transform : IEquatable<Transform>
+    public class Transform : IEquatable<Transform>
     {
         /** The translation caused by the transform */
         public Vec2 p;
@@ -57,6 +57,12 @@ namespace SharpBox2D.Common
         {
             p = _position.clone();
             q = _R.clone();
+        }
+        
+        public Transform()
+        {
+            p = new Vec2();
+            q = new Rot();
         }
 
         /** Set this to equal another transform. */

--- a/SharpBox2D/Common/Vec2.cs
+++ b/SharpBox2D/Common/Vec2.cs
@@ -31,7 +31,7 @@ namespace SharpBox2D.Common
  * A 2D column vector
  */
 
-    public struct Vec2 : IEquatable<Vec2>
+    public class Vec2 : IEquatable<Vec2>
     {
         public float x, y;
 
@@ -39,6 +39,12 @@ namespace SharpBox2D.Common
         {
             this.x = x;
             this.y = y;
+        }
+        
+        public Vec2()
+        {
+            this.x = 0;
+            this.y = 0;
         }
 
         public Vec2(Vec2 toCopy) : this(toCopy.x, toCopy.y)
@@ -316,11 +322,21 @@ namespace SharpBox2D.Common
 
         public static bool operator ==(Vec2 left, Vec2 right)
         {
+            if (ReferenceEquals(null, left))
+                return false;
+            if (ReferenceEquals(null, right))
+                return false;
+            
             return left.Equals(right);
         }
 
         public static bool operator !=(Vec2 left, Vec2 right)
         {
+            if (ReferenceEquals(null, left))
+                return false;
+            if (ReferenceEquals(null, right))
+                return false;
+            
             return !left.Equals(right);
         }
 

--- a/SharpBox2D/Common/Vec3.cs
+++ b/SharpBox2D/Common/Vec3.cs
@@ -32,7 +32,7 @@ namespace SharpBox2D.Common
  * @author Daniel Murphy
  */
 
-    public struct Vec3 : IEquatable<Vec3>
+    public class Vec3 : IEquatable<Vec3>
     {
         public float x, y, z;
 
@@ -41,6 +41,13 @@ namespace SharpBox2D.Common
             x = argX;
             y = argY;
             z = argZ;
+        }
+        
+        public Vec3()
+        {
+            x = 0;
+            y = 0;
+            z = 0;
         }
 
         public Vec3(Vec3 copy)
@@ -57,7 +64,7 @@ namespace SharpBox2D.Common
             z = vec.z;
             return this;
         }
-
+        
         public Vec3 set(float argX, float argY, float argZ)
         {
             x = argX;

--- a/SharpBox2D/Particle/ParticleDef.cs
+++ b/SharpBox2D/Particle/ParticleDef.cs
@@ -10,7 +10,7 @@ namespace SharpBox2D.Particle
    * chained by logical sums, for example: pd.flags = ParticleType.b2_elasticParticle |
    * ParticleType.b2_viscousParticle.
    */
-        internal int flags;
+        public int flags;
 
         /** The world position of the particle. */
         public Vec2 position = new Vec2();


### PR DESCRIPTION
This code was ported from Java and some parts still have
Java-styled functions that modify one or more class properties without
having ’out’ or ‘ref’ keywords on parameter list, breaking the logic
when classes are defined as value type instead of reference type as in
java. I changed these classes back to class from struct fixing those
issues and making sure that engine works as expected. That makes
particle simulation work as expected but that is not 100% correct way
to do this.
